### PR TITLE
Fixed downloader for Python 2.6 or earlier.

### DIFF
--- a/mfdl.py
+++ b/mfdl.py
@@ -16,7 +16,10 @@ try:
 except ImportError:
     from BeautifulSoup import BeautifulSoup
 from contextlib import closing
-from collections import OrderedDict
+try:
+	from collections import OrderedDict
+except ImportError:
+	from ordereddict import OrderedDict
 from itertools import islice
 
 URL_BASE = "http://mangafox.me/"


### PR DESCRIPTION
collections.OrderedDict is only present in Python 2.7 and above(so its not usable by Python 2.6 users).

However, it's really easy to drop-in a replacement so it's working in Python 2.6
See this: https://pypi.python.org/pypi/ordereddict
